### PR TITLE
fix(user-me-page): Redirect on user session expiration

### DIFF
--- a/frontend/src/app/pages/user/me/me.page.ts
+++ b/frontend/src/app/pages/user/me/me.page.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, effect, untracked } from '@angular/core';
+import { Router } from '@angular/router';
 
 import { ButtonModule } from 'primeng/button';
 
@@ -14,5 +15,10 @@ import { UserDetailsCardComponent } from '../components/user-details-card/user-d
 export class MePageComponent {
   protected readonly user = this.userMeService.loggedInUser;
 
-  constructor(private readonly userMeService: UserMeService) { }
+  constructor(private readonly userMeService: UserMeService, private readonly router: Router) {
+    effect(() => {
+      const user = this.user();
+      untracked(() => !user && void this.router.navigate(['/login']))
+    })
+  }
 }

--- a/frontend/src/app/services/user/user-me.service.ts
+++ b/frontend/src/app/services/user/user-me.service.ts
@@ -58,6 +58,7 @@ export class UserMeService {
             const { error } = httpError;
             this.messageService.add({ severity: 'error', summary: 'Error', detail: error?.error || error || 'Unknown error' })
           }
+          this.resetPreviousPoll.next();
           return of(null);
         }),
         finalize(() => this.isLoading.set(false)),


### PR DESCRIPTION
## Summary by Sourcery

Redirect unauthenticated users from the Me page to the login screen and ensure the user polling stream resets on service errors

Bug Fixes:
- Redirect to login when the user session expires on the Me page
- Reset the previous polling stream in UserMeService after an error