### PR TITLE
fix(user): Redirect on user session expiration

### DIFF
--- a/backend/middlewares/auth.go
+++ b/backend/middlewares/auth.go
@@ -16,7 +16,7 @@ func UserAuthSessionMiddleware() gin.HandlerFunc {
 		tokenString, err := context.Cookie("cubeshares.session")
 		if err != nil {
 			context.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
-				"error": "Missing token",
+				"error": "Authentication required",
 			})
 			return
 		}

--- a/frontend/src/app/pages/user/user.routes.ts
+++ b/frontend/src/app/pages/user/user.routes.ts
@@ -21,6 +21,7 @@ export const USER_ROUTES: Route[] = [
         path: 'me',
         canActivate: [isLoggedInGuard],
         component: MePageComponent,
+        data: { requiresAuth: true },
       },
       {
         path: ':id',

--- a/frontend/src/app/services/user/user-me.service.ts
+++ b/frontend/src/app/services/user/user-me.service.ts
@@ -1,5 +1,6 @@
-import { inject, Injectable, signal } from '@angular/core';
+import { effect, inject, Injectable, signal, untracked } from '@angular/core';
 import { HttpErrorResponse } from '@angular/common/http';
+import { Router } from '@angular/router';
 
 import { MessageService } from 'primeng/api';
 import {
@@ -24,12 +25,16 @@ export class UserMeService {
   readonly loggedInUser = signal<UserResponse | null>(null);
   readonly isLoading = signal<boolean>(true);
   readonly error = signal<HttpErrorResponse | null>(null);
+
   private readonly resetPreviousPoll = new Subject<void>();
+
   private readonly api = inject(ApiService);
+  private readonly router = inject(Router);
   private readonly messageService = inject(MessageService);
 
   constructor() {
     this.pollReadUserMe();
+    this.observeErrorState();
   }
 
   pollReadUserMe(): void {
@@ -52,13 +57,8 @@ export class UserMeService {
         take(1),
         tap(user => this.loggedInUser.set(user)),
         catchError((httpError: HttpErrorResponse) => {
-          this.loggedInUser.set(null);
-          this.error.set(httpError);
-          if (![401].includes(httpError.status)) {
-            const { error } = httpError;
-            this.messageService.add({ severity: 'error', summary: 'Error', detail: error?.error || error || 'Unknown error' })
-          }
           this.resetPreviousPoll.next();
+          this.error.set(httpError);
           return of(null);
         }),
         finalize(() => this.isLoading.set(false)),
@@ -66,6 +66,25 @@ export class UserMeService {
   }
 
   updateUserBio(requestBody: UpdateUserBioRequestBody): Observable<void> {
-    return this.api.update('user/me/bio', requestBody)
+    return this.api.update('user/me/bio', requestBody);
+  }
+
+  private observeErrorState(): void {
+    effect(() => {
+      const httpError = this.error();
+      untracked(() => {
+        if (httpError === null || !this.doesRouteRequireAuth()) return;
+        const { error } = httpError;
+        const detail = error?.error || error || 'Unknown error';
+        this.messageService.add({ severity: 'error', summary: 'Error', detail });
+        void this.router.navigate(['/login']);
+      });
+    });
+  }
+
+  private doesRouteRequireAuth(): boolean {
+    let route = this.router.routerState.snapshot.root;
+    while (route.firstChild) route = route.firstChild;
+    return !!route.data['requiresAuth'];
   }
 }


### PR DESCRIPTION
## Summary by Sourcery

Improve session expiration handling by resetting ongoing polls, clearing user data, redirecting to the login page on errors, and refining the backend unauthorized response message.

Bug Fixes:
- Redirect to the login page when the user session expires in UserMeService
- Reset previous user data polling and clear the user state on HTTP errors during user fetch
- Update the backend auth middleware to return "Authentication required" instead of "Missing token" for missing session cookies